### PR TITLE
modify page transitions about download

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,7 @@
   </Modal>
   <Toast
     v-model:list="toastList"
-    v-show="toastList.length > 0 && current_page != 'DownloadList'"
+    v-show="toastList.length > 0 && current_page != 'DownloadList' && current_page != 'Download'"
     @downloadToast="downloadToast"
     @removeToast="removeToast"
     ref="toast"
@@ -126,25 +126,6 @@ export default {
         this.onLogout();
       }
     });
-
-    //   if (this.initList) {
-    //     this.list = [];
-    //     docsApi.getDocumentList(true).then((data) => {
-    //       if (data) {
-    //         data.list.forEach((topics) => {
-    //           this.node_params_map[topics.topics_id] = {
-    //             node: null,
-    //             params: {
-    //               id: topics.topics_id,
-    //               public: true,
-    //             },
-    //           };
-    //           this.list.push(topics);
-    //         });
-    //         this.pageInfo = data.pageInfo;
-    //       }
-    //     });
-    //   }
   },
   methods: {
     linkNode(node, params) {

--- a/src/assets/scss/_button.scss
+++ b/src/assets/scss/_button.scss
@@ -29,6 +29,9 @@
     &:hover { 
       background-color: lighten($color-border, 16%);
     }
+    &:disabled {
+      background-color: lighten($color-border, 8%);
+    }
   }
   &--white-outline {
     border: 1px solid #fff !important;
@@ -79,6 +82,10 @@
   &--sm {
     flex: 0 0 auto !important;
     width: auto !important;
+  }
+  &--wide {
+    flex: 1 1 100% !important;
+    width: 100% !important;
   }
 
   // list

--- a/src/assets/scss/_modal.scss
+++ b/src/assets/scss/_modal.scss
@@ -153,7 +153,7 @@
     display: flex;
     justify-content: center;
     padding: $spacing-lg $spacing-x-lg;
-    background-color: darken($color-border, 16%);
+    background-color: darken($color-secondary, 16%);
     .docdog-modal__body + & {
       box-shadow: 0 0 10px 0 rgba(0,0,0,.2);
      }

--- a/src/assets/scss/_pagination.scss
+++ b/src/assets/scss/_pagination.scss
@@ -32,8 +32,7 @@
       }
     }
     span {
-      background-color: $color-link;
-      color: #fff;
+      background-color: $color-border;
     }
   }
 }

--- a/src/assets/scss/_toast.scss
+++ b/src/assets/scss/_toast.scss
@@ -70,4 +70,24 @@
       .docdog-button { height: 40px; }
     }
   }
+
+  // contract
+  &--contract {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    right: 40px;
+    bottom: 40px;
+    width: 50px;
+    height: 50px;
+    border-radius: $border-radius-md;
+    background: $color-primary;
+    box-shadow: 0 0 $spacing-md 0 rgba(0,0,0,.2);
+    transition: $transition;
+    z-index: 11200;
+    &:hover {
+      background-color: darken($color-primary, 8%);
+    }
+  }
 }

--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -1,18 +1,19 @@
 <template>
   <div class="docdog">
-    <section class="docdog-toast">
+    <button type="button" class="docdog-toast--contract" v-if="!toast_expand" @click="toast_expand = !toast_expand">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M7.41 16L12 11.42L16.59 16L18 14.59L12 8.59L6 14.59L7.41 16Z" fill="#ffffff"/>
+      </svg>
+    </button>
+    <section class="docdog-toast" v-if="toast_expand">
       <header class="docdog-toast__head">
         <p class="docdog-toast__head__heading">ダウンロードリスト</p>
-        <button type="button" aria-label="Close" class="docdog-toast__head__close" @click="removeAll">
-          <svg width="14" height="15" viewBox="0 0 14 15" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path
-              d="M11.0827 4.239L10.2602 3.4165L6.99935 6.67734L3.73852 3.4165L2.91602 4.239L6.17685 7.49984L2.91602 10.7607L3.73852 11.5832L6.99935 8.32234L10.2602 11.5832L11.0827 10.7607L7.82185 7.49984L11.0827 4.239Z"
-              fill="#AAAAAA"
-            />
+        <button type="button" aria-label="Close" class="docdog-toast__head__close" @click="toast_expand = !toast_expand">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M16.59 8.58997L12 13.17L7.41 8.58997L6 9.99997L12 16L18 9.99997L16.59 8.58997Z" fill="#666666"/>
           </svg>
         </button>
       </header>
-
       <!-- ダウンロードリストモーダル -->
       <div class="docdog-toast__body">
         <ul class="docdog-toast__body__list">
@@ -45,7 +46,9 @@ export default {
     },
   },
   data() {
-    return {};
+    return {
+      toast_expand: true,
+    };
   },
   methods: {
     downloadAll() {
@@ -53,9 +56,6 @@ export default {
     },
     removeByIdx(idx) {
       this.$emit('removeToast', idx);
-    },
-    removeAll() {
-      this.$emit('removeToast', null); // Removes all
     },
   },
 };

--- a/src/components/cards/CardModal.vue
+++ b/src/components/cards/CardModal.vue
@@ -9,7 +9,7 @@
         <button type="button" class="docdog-button docdog-button--secondary" @click="onDownload()">
           ダウンロードする
         </button>
-        <button type="button" class="docdog-button docdog-button--white" v-if="isInToast">追加済み</button>
+        <button type="button" class="docdog-button docdog-button--white" v-if="isInToast" disabled>追加済み</button>
         <button type="button" class="docdog-button docdog-button--white" v-else @click="onAdd()">
           ダウンロードリストに追加する
         </button>

--- a/src/components/modal_pages/Download.vue
+++ b/src/components/modal_pages/Download.vue
@@ -1,7 +1,9 @@
 <template>
-  <!-- Modal Content -->
-    <AlertSuccess v-if="msg" :msg="msg" />
-    <AlertError v-if="err" :err="err" />
+
+  <!-- TODO: Implement success message -->
+  <AlertSuccess v-if="msg" :msg="msg" />
+  <AlertError v-if="err" :err="err" />
+
   <div class="docdog-modal__body__section">
     <h1 class="docdog-modal__body__pagetitle">ダウンロード</h1>
   </div>
@@ -10,6 +12,7 @@
       <CardModal :data="data" :toastIds="toastIds" />
     </div>
   </div>
+
 </template>
 
 <script>

--- a/src/components/modal_pages/DownloadList.vue
+++ b/src/components/modal_pages/DownloadList.vue
@@ -1,13 +1,25 @@
 <template>
-  <!-- Modal Content -->
+
+  <!-- TODO: Implement success message -->
+  <AlertSuccess v-if="msg" :msg="msg" :msg2="msg2" />
+
   <div class="docdog-modal__body__section">
-    <p class="docdog-modal__body__heading">選択中のファイル</p>
+    <h1 class="docdog-modal__body__pagetitle">ダウンロードリスト</h1>
+  </div>
+
+  <div class="docdog-modal__body__section" v-if="list.length">
+    <p>選択中のファイル</p>
     <ul class="docdog-card__list">
       <li v-for="(item, idx) in list">
         <CardModal :data="item" :toastIds="toastIds" :deleteFooter="true" @removeToast="onRemoveToast(idx)" />
       </li>
     </ul>
   </div>
+
+  <div class="docdog-modal__body__section" v-if="!list.length">
+    <p>選択中のファイルはありません。</p>
+  </div>
+
 </template>
 
 <script>

--- a/src/components/modal_pages/Footer1.vue
+++ b/src/components/modal_pages/Footer1.vue
@@ -1,4 +1,6 @@
 <template>
+
+  <!-- TODO: Show only before download -->
   <div class="docdog-button__list">
     <button type="button" aria-label="Back to docs" class="docdog-button docdog-button--sm docdog-button--white-outline" @click.prevent="redirect({ target: 'List' })">
       <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#ffffff">
@@ -6,15 +8,9 @@
         <path d="M15.61 7.41L14.2 6l-6 6 6 6 1.41-1.41L11.03 12l4.58-4.59z" />
       </svg>
     </button>
-    <!-- <button type="button" class="docdog-button docdog-button--white">
-            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
-              <path d="M0 0h24v24H0V0z" fill="none" />
-              <path d="M15.61 7.41L14.2 6l-6 6 6 6 1.41-1.41L11.03 12l4.58-4.59z" />
-            </svg>
-      資料一覧へ戻る
-    </button> -->
-    <button type="button" class="docdog-button docdog-button--white" v-if="footer_data.isInToast">
-      ダウンロードリストに追加済み
+    <button type="button" class="docdog-button docdog-button--white" v-if="footer_data.isInToast" @click="$emit('downloadToast')">
+      追加済み<br>
+      ダウンロードリストを見る
     </button>
     <button type="button" class="docdog-button docdog-button--white" v-else @click="addToast">
       ダウンロードリストに追加する
@@ -23,6 +19,14 @@
       ダウンロードする
     </button>
   </div>
+
+  <!-- TODO: Show only after download -->
+  <div class="docdog-button__list">
+    <button type="button" class="docdog-button docdog-button--white docdog-button--wide" @click.prevent="redirect({ target: 'List' })">
+      資料一覧に戻る
+    </button>
+  </div>
+
 </template>
 
 <script>

--- a/src/components/modal_pages/Footer2.vue
+++ b/src/components/modal_pages/Footer2.vue
@@ -1,12 +1,22 @@
 <template>
+
+  <!-- TODO: Show only list count > 0 -->
   <div class="docdog-button__list">
-    <button type="button" class="docdog-button docdog-button--white"  @click.prevent="redirect({ target: 'List' })">
+    <button type="button" class="docdog-button docdog-button--white" @click.prevent="redirect({ target: 'List' })">
       資料一覧に戻る
     </button>
     <button type="button" class="docdog-button docdog-button--primary" @click="downloadToast">
       まとめてダウンロードする
     </button>
   </div>
+
+  <!-- TODO: Show only list count == 0 -->
+  <div class="docdog-button__list">
+    <button type="button" class="docdog-button docdog-button--white docdog-button--wide" @click.prevent="redirect({ target: 'List' })">
+      資料一覧に戻る
+    </button>
+  </div>
+
 </template>
 
 <script>


### PR DESCRIPTION
@artem-tim 
This is before Kato's review, but I send pr.
Please check and implement it.

### Page transition
- List -> Click "Add download list" button -> download list: https://diverta.gyazo.com/8cb4dc51389b108559c7a2accd7940d4
- List -> Click "Download" button -> download: https://diverta.gyazo.com/8459d7fada4e2a7f2c6d8a2e47072d4c

### Toast
I add expand / correct toast button.
I was able to complete it on my end.

### Download
- Please implement show modal footer buttons depend on download status.
  https://diverta.gyazo.com/ffde269ccf2c4eef86609386710690a6
- Please implement success screen.
  https://diverta.gyazo.com/5329092943e05f2447c9c0a74365782e

### Download list
- Please implement show modal footer buttons depend on download status.
  https://diverta.gyazo.com/439426d43e911d401fa9594fc54ebc4b
- Please implement success screen.
  https://diverta.gyazo.com/45323b6dbc601cf0c3ca4b2e62ef9f92
- Please change that don't close the modal if the download list reaches 0.
   https://diverta.gyazo.com/18a24514e6fda5ab30a4eaa42e5419c3